### PR TITLE
add key representation and mermaid ER diagrams support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,7 @@ type Documentation struct {
 	Directory string `json:"directory"`
 	Filename  string `json:"filename"`
 	Stdout    bool   `json:"stdout"`
+	Mermaid   bool   `json:"mermaid"`
 }
 
 func Default() *Config {

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -20,3 +20,5 @@ documentation:
   filename: "schema.md"
   # Write the output to STDOUT as well.
   stdout: true
+  # Write mermaid output
+  mermaid: true

--- a/db/db.go
+++ b/db/db.go
@@ -11,6 +11,7 @@ type Database interface {
 
 	ListTables(ctx context.Context, schema string) ([]string, error)
 	ListColumns(ctx context.Context, schema, table string) ([]TableColumn, error)
+	ListConstraints(ctx context.Context, schema, table string) ([]TableConstraint, error)
 }
 
 type TableColumn struct {
@@ -18,6 +19,35 @@ type TableColumn struct {
 	Type     string
 	Nullable bool
 	Default  string
+	PK       bool
+	FK       string
+	FK_ref   string
+	UK       bool
+}
+
+/*
+	tc.constraint_schema
+	, tc.constraint_name
+	, tc.constraint_type
+	, kcu1.constraint_schema
+	, kcu1.constraint_name
+	, kcu1.table_name from_table
+	, kcu1.column_name from_column
+	, kcu1.ordinal_position from_position
+	, kcu2.constraint_schema
+	, kcu2.constraint_name
+	, kcu2.table_name to_table
+	, kcu2.column_name to_column
+	, kcu2.ordinal_position to_position
+*/
+type TableConstraint struct {
+	Schema       string
+	Name         string
+	Type         string
+	TableColumn  string // referring column
+	TargetSchema string // referred schema
+	TargetTable  string // referred table
+	TargetColumn string // referred column
 }
 
 func New(url string) (Database, error) {

--- a/db/postgres.go
+++ b/db/postgres.go
@@ -56,8 +56,35 @@ func (p *Postgres) ListTables(ctx context.Context, schema string) ([]string, err
 	return tables, nil
 }
 
-const pgListColumns = `SELECT column_name, data_type, is_nullable, column_default FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2`
+const pgListColumns = `SELECT
+	c.column_name
+	, c.data_type
+	, c.is_nullable
+	, c.column_default
 
+FROM information_schema.columns c
+WHERE c.table_schema = $1 AND c.table_name = $2
+ORDER BY ordinal_position`
+
+/*
+const pgListColumns = `
+SELECT
+	c.column_name
+	, c.data_type
+	, c.is_nullable
+	, c.column_default
+	, tc.constraint_type,
+	, *
+FROM information_schema.columns c
+LEFT OUTER JOIN information_schema.key_column_usage k
+	ON c.column_name = k.column_name
+	AND c.table_name = k.table_name
+LEFT OUTER JOIN information_schema.table_constraints tc
+	ON tc.constraint_name = k.constraint_name
+WHERE c.table_name = $1
+	AND c.table_schema = $2
+`
+*/
 func (p *Postgres) ListColumns(ctx context.Context, schema, table string) ([]TableColumn, error) {
 	rows, err := p.db.QueryContext(ctx, pgListColumns, schema, table)
 	if err != nil {
@@ -85,4 +112,76 @@ func (p *Postgres) ListColumns(ctx context.Context, schema, table string) ([]Tab
 		return nil, err
 	}
 	return columns, nil
+}
+
+const pgListConstraints = `
+SELECT
+	  tc.constraint_schema
+	, tc.constraint_name
+	, tc.constraint_type
+--	, kcu1.constraint_schema
+--	, kcu1.constraint_name
+--	, kcu1.table_name from_table
+	, kcu1.column_name from_column
+--	, kcu1.ordinal_position from_position
+--	, kcu2.constraint_schema
+--	, kcu2.constraint_name
+	, kcu2.table_schema to_schema
+	, kcu2.table_name to_table
+	, kcu2.column_name to_column
+--  , kcu2.ordinal_position to_position
+FROM information_schema.table_constraints tc
+LEFT OUTER JOIN information_schema.referential_constraints rc
+  	USING(constraint_schema, constraint_name)
+JOIN information_schema.key_column_usage as kcu1
+    ON  kcu1.constraint_catalog = tc.constraint_catalog
+    AND kcu1.constraint_schema  = tc.constraint_schema
+    AND kcu1.constraint_name    = tc.constraint_name
+LEFT OUTER JOIN information_schema.key_column_usage as kcu2
+    ON kcu2.constraint_catalog = rc.unique_constraint_catalog
+    AND kcu2.constraint_schema = rc.unique_constraint_schema
+    AND kcu2.constraint_name   = rc.unique_constraint_name
+    AND kcu2.ordinal_position  = kcu1.ordinal_position
+WHERE   tc.table_name = $2
+	AND tc.table_schema = $1
+`
+
+func (p *Postgres) ListConstraints(ctx context.Context, schema, table string) ([]TableConstraint, error) {
+	rows, err := p.db.QueryContext(ctx, pgListConstraints, schema, table)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var constraints []TableConstraint
+	for rows.Next() {
+		var c TableConstraint
+		var tblColumn sql.NullString
+		var tgtSchema sql.NullString
+		var tgtTable sql.NullString
+		var tgtColumn sql.NullString
+		if err := rows.Scan(&c.Schema, &c.Name, &c.Type, &tblColumn, &tgtSchema, &tgtTable, &tgtColumn); err != nil {
+			return nil, err
+		}
+		if tblColumn.Valid {
+			c.TableColumn = tblColumn.String
+		}
+		if tgtSchema.Valid {
+			c.TargetSchema = tgtSchema.String
+		}
+		if tgtTable.Valid {
+			c.TargetTable = tgtTable.String
+		}
+		if tgtColumn.Valid {
+			c.TargetColumn = tgtColumn.String
+		}
+
+		constraints = append(constraints, c)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return constraints, nil
 }


### PR DESCRIPTION
Draft: This is a first attempt to put PK , FK an UK (using information_schema rather than  pg_catalog) and referred columns. 
This patch also draws basic mermaid.js Entity Relationship (not good for edges).
Add configuration switch to enable/disable mermaid generation.